### PR TITLE
feature: support leader election

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.2.7
-	honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc // indirect
 	k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d
 	k8s.io/client-go v0.0.0-20190819141724-e14f31a72a77

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,7 @@ github.com/elastic/go-elasticsearch/v7 v7.4.1/go.mod h1:OJ4wdbtDNk5g503kvlHLyErC
 github.com/elazarl/goproxy v0.0.0-20170405201442-c4fc26588b6e/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550 h1:mV9jbLoSW/8m4VK16ZkHTozJa8sesK5u5kTMFysTYac=
 github.com/evanphx/json-patch v0.0.0-20190203023257-5858425f7550/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
@@ -295,6 +296,7 @@ k8s.io/klog v0.3.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v0.3.1/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
+k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30 h1:TRb4wNWoBVrH9plmkp2q86FIDppkbrEXdXlxU3a3BMI=
 k8s.io/kube-openapi v0.0.0-20190228160746-b3a7cee44a30/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 k8s.io/utils v0.0.0-20190221042446-c2654d5206da/go.mod h1:8k8uAuAQ0rXslZKaEWd0c3oVhZz7sSzSiPnVZayjIX0=
 k8s.io/utils v0.0.0-20190923111123-69764acb6e8e h1:BXSmdH6S3YGLlhC89DZp+sNdYSmwNeDU6Xu5ZpzGOlM=

--- a/pkg/kube/leaderelection.go
+++ b/pkg/kube/leaderelection.go
@@ -1,0 +1,99 @@
+package kube
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/leaderelection"
+	"k8s.io/client-go/tools/leaderelection/resourcelock"
+)
+
+const (
+	inClusterNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+	defaultNamespace       = "default"
+	defaultLeaseDuration   = 15 * time.Second
+	defaultRenewDeadline   = 10 * time.Second
+	defaultRetryPeriod     = 2 * time.Second
+)
+
+// NewResourceLock creates a new config map resource lock for use in a leader
+// election loop
+func newResourceLock(config *rest.Config, leaderElectionID string) (resourcelock.Interface, error) {
+	// LeaderElectionID must be provided to prevent clashes
+	if leaderElectionID == "" {
+		return nil, errors.New("LeaderElectionID must be configured")
+	}
+
+	leaderElectionNamespace, err := getInClusterNamespace()
+	if err != nil {
+		leaderElectionNamespace = defaultNamespace
+	}
+
+	// Leader id, needs to be unique
+	id, err := os.Hostname()
+	if err != nil {
+		return nil, err
+	}
+	id = id + "_" + string(uuid.NewUUID())
+
+	// Construct client for leader election
+	client, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(JoelSpeed): switch to leaderelection object in 1.12
+	return resourcelock.New(resourcelock.ConfigMapsResourceLock,
+		leaderElectionNamespace,
+		leaderElectionID,
+		client.CoreV1(),
+		client.CoordinationV1(),
+		resourcelock.ResourceLockConfig{
+			Identity: id,
+		})
+}
+
+func getInClusterNamespace() (string, error) {
+	// Check whether the namespace file exists.
+	// If not, we are not running in cluster so can't guess the namespace.
+	_, err := os.Stat(inClusterNamespacePath)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("not running in-cluster, please specify leaderElectionIDspace")
+	} else if err != nil {
+		return "", fmt.Errorf("error checking namespace file: %w", err)
+	}
+
+	// Load the namespace file and return its content
+	namespace, err := ioutil.ReadFile(inClusterNamespacePath)
+	if err != nil {
+		return "", fmt.Errorf("error reading namespace file: %w", err)
+	}
+	return string(namespace), nil
+}
+
+// NewLeaderElector return  a leader elector object using client-go
+func NewLeaderElector(leaderElectionID string, config *rest.Config, startFunc func(context.Context), stopFunc func()) (*leaderelection.LeaderElector, error) {
+	resourceLock, err := newResourceLock(config, leaderElectionID)
+	if err != nil {
+		return &leaderelection.LeaderElector{}, err
+	}
+
+	l, err := leaderelection.NewLeaderElector(leaderelection.LeaderElectionConfig{
+		Lock:          resourceLock,
+		LeaseDuration: defaultLeaseDuration,
+		RenewDeadline: defaultRenewDeadline,
+		RetryPeriod:   defaultRetryPeriod,
+		Callbacks: leaderelection.LeaderCallbacks{
+			OnStartedLeading: startFunc,
+			OnStoppedLeading: stopFunc,
+		},
+	})
+	return l, err
+}


### PR DESCRIPTION
leaderelection mechanism is copied from client-go and controller-runtime.
leaderelection cannot be disabled and configured for now, because we don't think it shuold be disabled or configured by user.

---

## 代码介绍
`kubernetes-event-exporter` 的启动主要包含2部分，一部分是启动 engine(`main.go` 中的 `engine.Start`) 负责初始化 sinks 并将 channel 中的事件分发到 sinks 中，另一部分是启动 watcher(`main.go` 中的 `w.Start`) 负责使用 client-go 的 informer 侦听事件对象并传送到 channel 中。engine 和 watcher 之间是消费者与生产者的关系。我们只把生产者 watcher 的启动和停止放到选举成功与失败后运行，消费者 engine 在程序开始和退出时启动和退出即可。

`pkg/kube/leaderelection.go` 负责创建选举器，`main.go` 负责启动选举器。
代码主要来源于 controller-runtime 中的 https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/leaderelection/leader_election.go (创建 `ResourceLock`)和 https://github.com/kubernetes-sigs/controller-runtime/blob/8507812d8a0958bdabd6560a6f1ed5e75fb8bb18/pkg/manager/internal.go#L506 (启动选举)。

## 验证步骤
在本地开启3个终端运行程序，只有1个终端输出 `leader election got` 并开始输出运行日志，其它2个终端均卡在 `attempting to acquire leader lease` 步骤。
将正在运行的程序杀掉，会输出 `leader election lost` 日志并退出，另外的2个终端中的1个会输出`leader election got` 并开始输出运行日志。