### PR TITLE
feature: add file rotate function to file sink.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	google.golang.org/grpc v1.27.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 	gopkg.in/yaml.v2 v2.2.7
 	k8s.io/api v0.0.0-20190819141258-3544db3b9e44
 	k8s.io/apimachinery v0.0.0-20190817020851-f2f3a405f61d

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/Azure/go-autorest v11.1.2+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/goutils v1.1.0 h1:zukEsf/1JZwCMgHiK3GZftabmxiCw4apj3a28RPBiVg=
 github.com/Masterminds/goutils v1.1.0/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
@@ -275,6 +276,8 @@ gopkg.in/jcmturner/gokrb5.v7 v7.2.3 h1:hHMV/yKPwMnJhPuPx7pH2Uw/3Qyf+thJYlisUc440
 gopkg.in/jcmturner/gokrb5.v7 v7.2.3/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/jcmturner/rpc.v1 v1.1.0 h1:QHIUxTX1ISuAv9dD2wJ9HWQVuWDX/Zc0PfeC2tjc4rU=
 gopkg.in/jcmturner/rpc.v1 v1.1.0/go.mod h1:YIdkC4XfD6GXbzje11McwsDuOlZQSb9W4vfLvuNnlv8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0 h1:1Lc07Kr7qY4U2YPouBjpCLxpiyxIVoxqXgkXLknAOE8=
+gopkg.in/natefinch/lumberjack.v2 v2.0.0/go.mod h1:l0ndWWf7gzL7RNwBG7wST/UCcT4T24xpD6X8LsfU/+k=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/pkg/sinks/file.go
+++ b/pkg/sinks/file.go
@@ -3,14 +3,18 @@ package sinks
 import (
 	"context"
 	"encoding/json"
-	"os"
+	"io"
 
 	"github.com/opsgenie/kubernetes-event-exporter/pkg/kube"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 type FileConfig struct {
-	Path   string                 `yaml:"path"`
-	Layout map[string]interface{} `yaml:"layout"`
+	Path       string                 `yaml:"path"`
+	Layout     map[string]interface{} `yaml:"layout"`
+	MaxSize    int                    `yaml:"maxsize"`
+	MaxAge     int                    `yaml:"maxage"`
+	MaxBackups int                    `yaml:"maxbackups"`
 }
 
 func (f *FileConfig) Validate() error {
@@ -18,27 +22,28 @@ func (f *FileConfig) Validate() error {
 }
 
 type File struct {
-	file    *os.File
+	writer  io.WriteCloser
 	encoder *json.Encoder
 	layout  map[string]interface{}
 }
 
 func NewFileSink(config *FileConfig) (*File, error) {
-	file, err := os.OpenFile(config.Path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-
-	if err != nil {
-		return nil, err
+	writer := &lumberjack.Logger{
+		Filename:   config.Path,
+		MaxSize:    config.MaxSize,
+		MaxBackups: config.MaxBackups,
+		MaxAge:     config.MaxAge,
 	}
 
 	return &File{
-		file:    file,
-		encoder: json.NewEncoder(file),
+		writer:  writer,
+		encoder: json.NewEncoder(writer),
 		layout:  config.Layout,
 	}, nil
 }
 
 func (f *File) Close() {
-	_ = f.file.Close()
+	_ = f.writer.Close()
 }
 
 func (f *File) Send(ctx context.Context, ev *kube.EnhancedEvent) error {


### PR DESCRIPTION
add the following arguments to specify file sink's rotation behavior:

```yaml
- receivers:
  file:
    path: ./test.log
    maxsize: 20    // if ./test.log is larger than 20MB, it will be renamed to ./test-<datetime>.log as a backup file,
    and create a new file named test.log to receive events. It defaults to 100 megabytes.
    maxage: 20     // if backup files ./test-<datetime>.log are created 20 days ago, they will be deleted. The default
    is not to remove old log files based on age.
    maxbackups: 3  // if backup files are more than 3, older backup files will be removed.
```

the rotating function is powered by [lumberjack](https://github.com/natefinch/lumberjack) which is also used by
kubernetes. Becasue `lumberjack.Logger` implmented `io.WriteCloser`, so it is easy to replace `file *os.file` with `writer &lumberjack.Logger`.

## testing
run kubernetes-event-exporter with following config:
```yaml
logLevel: debug
route:
  match:
    - receiver: "file"
receivers:
  - name: "file"
    file:
      path: "./event.log"
      maxsize: 1
      maxbackups: 4
```
run following script to generate events and output `./event*.log` status:
```shell
while true
do
  kubectl run nginx --image nginx || kubectl delete deployment nginx
  ls -lh event*.log
  sleep 2
done
```
the result is:
```
deployment.apps "nginx" deleted
-rw-r--r-- 1 ysyou staff  1.0M Mar  4 18:03 event-2020-03-04T10-03-30.271.log
-rw-r--r-- 1 ysyou staff  1.0M Mar  4 18:15 event-2020-03-04T10-15-52.496.log
-rw-r--r-- 1 ysyou staff  1.0M Mar  4 18:28 event-2020-03-04T10-28-27.334.log
-rw-r--r-- 1 ysyou staff  1.0M Mar  4 18:41 event-2020-03-04T10-41-11.316.log
-rw-r--r-- 1 ysyou staff 1023K Mar  4 18:54 event.log
deployment.apps/nginx created
-rw-r--r-- 1 ysyou staff 1.0M Mar  4 18:15 event-2020-03-04T10-15-52.496.log
-rw-r--r-- 1 ysyou staff 1.0M Mar  4 18:28 event-2020-03-04T10-28-27.334.log
-rw-r--r-- 1 ysyou staff 1.0M Mar  4 18:41 event-2020-03-04T10-41-11.316.log
-rw-r--r-- 1 ysyou staff 1.0M Mar  4 18:54 event-2020-03-04T10-54-11.451.log
-rw-r--r-- 1 ysyou staff 2.0K Mar  4 18:54 event.log
```
when `event.log` reaches 1M, it is renamed to `event-2020-03-04T10-54-11.451.log`, because backup files are more than 4, the oldest one `event-2020-03-04T10-03-30.271.log` is deleted.