### PR TITLE
kubernetes-event-exporter should exit after leader lost.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY go.sum go.sum
 RUN go mod download
 
 ADD . /app
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO11MODULE=on go build -v -a -o /main .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -v -a -o /main .
 
 FROM alpine:3.7
 COPY --from=builder /main /kubernetes-event-exporter


### PR DESCRIPTION
related jira: http://jira.alauda.cn/browse/AIT-2154

之前 kubernetes-event-exporter 在由于 apiserver 无法访问导致选举丢失后会停止工作但不会退出，导致改实例无法再重新进行选举。
目前改成和 kubebuilder controller-runtime 一致的做法：在选举丢失后应用退出重新调度。